### PR TITLE
Corrected reset value of version register in SPI flash register block

### DIFF
--- a/docs/source/rb/flash_spi.rst
+++ b/docs/source/rb/flash_spi.rst
@@ -13,7 +13,7 @@ The SPI flash register block has a header with type 0x0000C120, version 0x000002
     ========  =============  ======  ======  ======  ======  =============
     RBB+0x00  Type           Vendor ID       Type            RO 0x0000C120
     --------  -------------  --------------  --------------  -------------
-    RBB+0x04  Version        Major   Minor   Patch   Meta    RO 0x00000100
+    RBB+0x04  Version        Major   Minor   Patch   Meta    RO 0x00000200
     --------  -------------  ------  ------  ------  ------  -------------
     RBB+0x08  Next pointer   Pointer to next register block  RO -
     --------  -------------  ------------------------------  -------------


### PR DESCRIPTION
It was inconsistent with the value in the sentence directly above. The driver also reports the version string `v 0.0.2.0`.
> [155678.297659] mqnic 0000:01:00.0:  type 0x0000c120 (v 0.0.2.0)